### PR TITLE
define regex pattern as raw string because of invalid escape sequence

### DIFF
--- a/simple_addr.py
+++ b/simple_addr.py
@@ -428,7 +428,7 @@ def remove_comments_from_sender(instring):
     # [^\(] # followed by anything that's not a left paren
     # *?    # a non-greedy number of times
     # \)    # followed by right paren
-    parens_re = re.compile("\([^\(]*?\)")
+    parens_re = re.compile(r"\([^\(]*?\)")
     instring = parens_re.sub('', instring)
     if "(" in instring:
         return remove_comments_from_sender(instring)


### PR DESCRIPTION
when searching for addresses with TAB on new mail creation i get the 

```
error "invalid escape sequence '\('`
```

to fix this i set the regex to a raw string. 

https://docs.python.org/3/library/re.html#raw-string-notation